### PR TITLE
⚡️  Improve performance on migrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ yourself.
 require 'virsandra'
 
 Virsandra.configure do |c|
-  c.servers = "127.0.0.1"
+  c.servers = ENV.fetch('CASSANDRA_HOST')
   c.keyspace = "example_keyspace"
 end
 ````

--- a/lib/virsandra/configuration.rb
+++ b/lib/virsandra/configuration.rb
@@ -8,7 +8,7 @@ module Virsandra
     ].freeze
 
     DEFAULT_OPTION_VALUES = {
-      servers: "127.0.0.1",
+      servers: "localhost",
       consistency: :quorum,
       credentials: {}
     }.freeze

--- a/lib/virsandra/migration.rb
+++ b/lib/virsandra/migration.rb
@@ -4,6 +4,7 @@ module Virsandra
       @file_paths = sort_file_paths(file_paths)
       @options = options
       @migration_table = Virsandra::Migrations::Table.new(@options[:keyspace])
+      @existing_versions = @migration_table.versions
     end
 
     def migrate_up
@@ -35,7 +36,7 @@ module Virsandra
 
     def pending_migrations
       filtered_paths.reject do |path|
-        @migration_table.versions.any? do |version|
+        @existing_versions.any? do |version|
           path.match(version_regexp(version))
         end
       end

--- a/lib/virsandra/migration.rb
+++ b/lib/virsandra/migration.rb
@@ -8,7 +8,6 @@ module Virsandra
     end
 
     def migrate_up
-      require_files
       migrate_files(:up)
     end
 
@@ -20,14 +19,9 @@ module Virsandra
       end
     end
 
-    def require_files
-      pending_migrations.each do |file_path|
-        ::Kernel.require(file_path)
-      end
-    end
-
     def migrate_files(direction)
       pending_migrations.each do |file_path|
+        ::Kernel.require(file_path)
         klass = file_path_to_klass(file_path)
         klass.new.send(direction)
         @migration_table.mark_as_migrated(version_from_path(file_path))

--- a/spec/lib/virsandra/configuration_spec.rb
+++ b/spec/lib/virsandra/configuration_spec.rb
@@ -4,7 +4,7 @@ describe Virsandra::Configuration do
   subject(:config){ described_class.new(given_options) }
   let(:given_options){ {} }
 
-  its(:servers){ should eq("127.0.0.1") }
+  its(:servers){ should eq("localhost") }
   its(:consistency){ should eq(:quorum) }
   its(:keyspace){ should be_nil }
 
@@ -44,7 +44,7 @@ describe Virsandra::Configuration do
       config.to_hash.should eq({
         consistency: :quorum,
         keyspace: nil,
-        servers: "127.0.0.1",
+        servers: "localhost",
         credentials: {username: '', password: ''}
       })
     end

--- a/spec/lib/virsandra/cql_value_spec.rb
+++ b/spec/lib/virsandra/cql_value_spec.rb
@@ -7,7 +7,7 @@ describe Virsandra::CQLValue do
   it "returns plain numbers" do
     subject.convert(10).should == "10"
     subject.convert(10.0).should == "10.0"
-    subject.convert(BigDecimal.new("10.0")).should == "0.1E2"
+    subject.convert(BigDecimal.new("10.0")).upcase.should == "0.1E2"
   end
 
   it "quotes strings" do


### PR DESCRIPTION
- [x] ⚡️ Store existing migrated versions to save some queries on cassandra

For a project with 137 migrations (as an hypothetical example) this PR will save to query in cassandra for versions **twice - 1** (273 saved queries in this example).

The current code run the following query for each file to migrate to
check if it was migrated already or not. In this context the `versions`
values could be memoized or loaded in the object initialization.

```ruby
query = Virsandra::SelectQuery.new("name").from(SCHEMA_TABLE)
keyspace.execute(query.to_s).to_a.map(&:values).flatten
```